### PR TITLE
Add .gitignore at top level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+Debug/
+Release/
+
+*~


### PR DESCRIPTION
Ignore emacs ~ files.

Ignore Release and Debug directories created during build.  These are
ignored in some of the subdirectories but not others so better to just
do it at the top level for all of them.